### PR TITLE
Clarify score weights and add user manual

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Manual from "./pages/Manual";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/manual" element={<Manual />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/features/estimator/components/Sidebar.tsx
+++ b/src/features/estimator/components/Sidebar.tsx
@@ -68,6 +68,15 @@ export default function Sidebar({ settings, setSettings, onReset, ctrError, head
     setSettings({ ...settings, cohorts: list });
   };
 
+  const weightLabels: Record<keyof ScoreWeights, string> = {
+    positionGap: "Position gap",
+    keywordDifficulty: "Keyword difficulty",
+    serpComplexity: "SERP complexity",
+    contentMatch: "Content match",
+    linkGap: "Link gap",
+    base_stay: "Base stay",
+  };
+
   return (
     <aside className="w-full lg:w-[360px] xl:w-[400px] shrink-0 p-4 space-y-4 bg-card/60 backdrop-blur rounded-lg border" aria-label="Controls sidebar">
       <h2 className="text-lg font-semibold">Settings</h2>
@@ -141,19 +150,19 @@ export default function Sidebar({ settings, setSettings, onReset, ctrError, head
           </Card>
         </TabsContent>
         <TabsContent value="score">
-          <Card className="p-4 space-y-4">
-            <h3 className="text-sm font-medium flex items-center gap-2">Weights <HelpTooltip content="Adjust how features influence each bucket score; probabilities are computed via softmax. base_stay controls p(stay)." /></h3>
-            {(["w1","w2","w3","w4","w5"] as (keyof ScoreWeights)[]).map((k) => (
-              <div key={k} className="space-y-1">
-                <div className="flex justify-between text-xs"><Label>{k}</Label><span>{settings.weights[k].toFixed(2)}</span></div>
-                <Slider value={[settings.weights[k]]} onValueChange={(v) => setWeights({ [k]: v[0] } as any)} min={0} max={1} step={0.01} />
+            <Card className="p-4 space-y-4">
+              <h3 className="text-sm font-medium flex items-center gap-2">Weights <HelpTooltip content="Adjust how features influence each bucket score; probabilities are computed via softmax. base_stay controls p(stay)." /></h3>
+              {(["positionGap","keywordDifficulty","serpComplexity","contentMatch","linkGap"] as (keyof ScoreWeights)[]).map((k) => (
+                <div key={k} className="space-y-1">
+                  <div className="flex justify-between text-xs"><Label>{weightLabels[k]}</Label><span>{settings.weights[k].toFixed(2)}</span></div>
+                  <Slider value={[settings.weights[k]]} onValueChange={(v) => setWeights({ [k]: v[0] } as any)} min={0} max={1} step={0.01} />
+                </div>
+              ))}
+              <div className="space-y-1">
+                <div className="flex justify-between text-xs"><Label>base_stay</Label><span>{settings.weights.base_stay.toFixed(2)}</span></div>
+                <Slider value={[settings.weights.base_stay]} onValueChange={(v) => setWeights({ base_stay: v[0] })} min={0} max={0.6} step={0.01} />
               </div>
-            ))}
-            <div className="space-y-1">
-              <div className="flex justify-between text-xs"><Label>base_stay</Label><span>{settings.weights.base_stay.toFixed(2)}</span></div>
-              <Slider value={[settings.weights.base_stay]} onValueChange={(v) => setWeights({ base_stay: v[0] })} min={0} max={0.6} step={0.01} />
-            </div>
-          </Card>
+            </Card>
         </TabsContent>
       </Tabs>
 

--- a/src/features/estimator/components/TopBar.tsx
+++ b/src/features/estimator/components/TopBar.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import FileUploader from "./FileUploader";
 import { HelpTooltip } from "@/components/HelpTooltip";
+import { Link } from "react-router-dom";
 
 interface Props {
   onFile: (file: File) => void;
@@ -24,6 +25,7 @@ export default function TopBar({ onFile, loadSample, setLoadSample }: Props) {
             <HelpTooltip content="Upload a SEMrush CSV/XLSX export (first sheet). Then map the columns on the left." />
           </div>
           <Button asChild variant="secondary"><a href="https://semrush.com" target="_blank" rel="noreferrer">SEMrush</a></Button>
+          <Link to="/manual" className="text-sm underline">Mode d'emploi</Link>
         </div>
       </div>
     </header>

--- a/src/features/estimator/constants.ts
+++ b/src/features/estimator/constants.ts
@@ -40,10 +40,10 @@ export const DEFAULT_COHORTS: CohortRule[] = [
 ];
 
 export const DEFAULT_WEIGHTS: ScoreWeights = {
-  w1: 0.35,
-  w2: 0.25,
-  w3: 0.3,
-  w4: 0.2,
-  w5: 0.25,
+  positionGap: 0.35,
+  keywordDifficulty: 0.25,
+  serpComplexity: 0.3,
+  contentMatch: 0.2,
+  linkGap: 0.25,
   base_stay: 0.15,
 };

--- a/src/features/estimator/model.ts
+++ b/src/features/estimator/model.ts
@@ -52,10 +52,30 @@ export function scoreProbs(row: KeywordRow, weights: ScoreWeights) {
   const contentMatch = 0; // placeholder, not available
   const linkGapStd = 0; // placeholder, not available
 
-  const s13 = 0 + weights.w1 * (-gap(centers.B13)) + weights.w2 * (-kdStd) + weights.w3 * (-serpStd) + weights.w4 * contentMatch + weights.w5 * (-linkGapStd);
-  const s46 = 0 + weights.w1 * (-gap(centers.B46)) + weights.w2 * (-kdStd) + weights.w3 * (-serpStd) + weights.w4 * contentMatch + weights.w5 * (-linkGapStd);
-  const s710 = 0 + weights.w1 * (-gap(centers.B710)) + weights.w2 * (-kdStd) + weights.w3 * (-serpStd) + weights.w4 * contentMatch + weights.w5 * (-linkGapStd);
-  const s1120 = 0 + weights.w1 * (-gap(centers.B1120)) + weights.w2 * (-kdStd) + weights.w3 * (-serpStd) + weights.w4 * contentMatch + weights.w5 * (-linkGapStd);
+  const s13 = 0
+    + weights.positionGap * (-gap(centers.B13))
+    + weights.keywordDifficulty * (-kdStd)
+    + weights.serpComplexity * (-serpStd)
+    + weights.contentMatch * contentMatch
+    + weights.linkGap * (-linkGapStd);
+  const s46 = 0
+    + weights.positionGap * (-gap(centers.B46))
+    + weights.keywordDifficulty * (-kdStd)
+    + weights.serpComplexity * (-serpStd)
+    + weights.contentMatch * contentMatch
+    + weights.linkGap * (-linkGapStd);
+  const s710 = 0
+    + weights.positionGap * (-gap(centers.B710))
+    + weights.keywordDifficulty * (-kdStd)
+    + weights.serpComplexity * (-serpStd)
+    + weights.contentMatch * contentMatch
+    + weights.linkGap * (-linkGapStd);
+  const s1120 = 0
+    + weights.positionGap * (-gap(centers.B1120))
+    + weights.keywordDifficulty * (-kdStd)
+    + weights.serpComplexity * (-serpStd)
+    + weights.contentMatch * contentMatch
+    + weights.linkGap * (-linkGapStd);
 
   const exps = softmax([s13, s46, s710, s1120]);
   const [B13, B46, B710, B1120] = exps;

--- a/src/features/estimator/types.ts
+++ b/src/features/estimator/types.ts
@@ -50,7 +50,12 @@ export interface CohortRule {
 }
 
 export interface ScoreWeights {
-  w1: number; w2: number; w3: number; w4: number; w5: number; base_stay: number;
+  positionGap: number;
+  keywordDifficulty: number;
+  serpComplexity: number;
+  contentMatch: number;
+  linkGap: number;
+  base_stay: number;
 }
 
 export interface FiltersState {

--- a/src/pages/Manual.tsx
+++ b/src/pages/Manual.tsx
@@ -1,0 +1,24 @@
+import { Link } from "react-router-dom";
+
+export default function Manual() {
+  return (
+    <main className="min-h-screen">
+      <header className="sticky top-0 z-10 bg-background/70 backdrop-blur border-b">
+        <div className="max-w-screen-2xl mx-auto px-4 py-3 flex items-center justify-between gap-4">
+          <h1 className="text-xl font-semibold">Mode d'emploi</h1>
+          <Link to="/" className="text-sm underline">Retour</Link>
+        </div>
+      </header>
+      <section className="max-w-screen-md mx-auto p-4 space-y-4">
+        <p>Cette application estime le trafic SEO incrémental à partir de vos mots-clés.</p>
+        <ol className="list-decimal list-inside space-y-2">
+          <li>Téléchargez votre fichier SEMrush et chargez-le en haut de l'écran.</li>
+          <li>Associez chaque colonne à son champ dans le panneau de gauche.</li>
+          <li>Ajustez les poids, les CTR et les autres paramètres selon vos hypothèses.</li>
+          <li>Analysez le tableau pour voir les clics attendus et les gains potentiels.</li>
+        </ol>
+        <p>Revenez à l'outil principal pour tester différentes configurations.</p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- rename score weight fields to descriptive names and update usage
- show friendly labels for weights in the Score tab
- add a “Mode d'emploi” manual page linked from the top bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899ce3ae10c8324b553133bc0da0d77