### PR TITLE
feat: add URL filter and improve tooltips

### DIFF
--- a/src/components/HelpTooltip.tsx
+++ b/src/components/HelpTooltip.tsx
@@ -1,5 +1,5 @@
 import { HelpCircle } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 interface HelpTooltipProps {
@@ -9,19 +9,21 @@ interface HelpTooltipProps {
 
 export function HelpTooltip({ content, className }: HelpTooltipProps) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          aria-label="Help"
-          className={cn("inline-flex items-center align-middle", className)}
-        >
-          <HelpCircle className="h-4 w-4 text-muted-foreground hover:text-foreground" />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="top" align="start" className="max-w-xs leading-relaxed text-sm">
-        {content}
-      </TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            aria-label="Help"
+            className={cn("inline-flex items-center align-middle cursor-help", className)}
+          >
+            <HelpCircle className="h-4 w-4 text-muted-foreground" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="start" className="max-w-xs leading-relaxed text-sm">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/src/features/estimator/types.ts
+++ b/src/features/estimator/types.ts
@@ -59,13 +59,15 @@ export interface ScoreWeights {
 }
 
 export interface FiltersState {
-  brandOn: boolean;
-  brandMode: "include" | "exclude";
-  brandTerms: string;
-  minVolume: number;
-  countryIn: string[];
-  deviceIn: string[];
-}
+    brandOn: boolean;
+    brandMode: "include" | "exclude";
+    brandTerms: string;
+    minVolume: number;
+    countryIn: string[];
+    deviceIn: string[];
+    urlMode: "contains" | "exact";
+    urlValue: string;
+  }
 
 export interface SettingsState {
   ctr: CTRBuckets;


### PR DESCRIPTION
## Summary
- allow filtering keywords by URL with contains/exact option and URL suggestions
- show help tooltips on hover and add explanations for score weight sliders
- refactor tooltip component for reliable hover behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6899d204f50083249c4ad61dc121ee2e