### PR TITLE
feat: add intent and position filters

### DIFF
--- a/src/features/estimator/components/Sidebar.tsx
+++ b/src/features/estimator/components/Sidebar.tsx
@@ -58,9 +58,10 @@ interface SidebarProps {
   urls: string[];
   countries: string[];
   devices: string[];
+  intents: string[];
 }
 
-export default function Sidebar({ settings, setSettings, onReset, ctrError, headers, mapping, onMappingChange, filters, setFilters, urls, countries, devices }: SidebarProps) {
+export default function Sidebar({ settings, setSettings, onReset, ctrError, headers, mapping, onMappingChange, filters, setFilters, urls, countries, devices, intents }: SidebarProps) {
   const sumErr = useMemo(() => validateCohorts(settings.cohorts), [settings.cohorts]);
 
   const setCTR = (k: keyof CTRBuckets, v: number) => setSettings({ ...settings, ctr: { ...settings.ctr, [k]: clamp(v, 0, 100) } });
@@ -136,6 +137,23 @@ export default function Sidebar({ settings, setSettings, onReset, ctrError, head
               <option key={d} value={d} />
             ))}
           </datalist>
+        </div>
+        <div className="space-y-1">
+          <Label className="flex items-center gap-2">Intention <HelpTooltip content="Filtrer les requêtes selon l'intention." /></Label>
+          <Input list="intent-options" placeholder="informational,commercial" value={filters.intentIn.join(",")}
+            onChange={(e) => setFilters({ ...filters, intentIn: e.target.value.split(',').map((c) => c.trim()).filter(Boolean) })} />
+          <datalist id="intent-options">
+            {intents.map((i) => (
+              <option key={i} value={i} />
+            ))}
+          </datalist>
+        </div>
+        <div className="space-y-1">
+          <Label className="flex items-center gap-2">Plage de position <HelpTooltip content="Inclure seulement les positions dans cet intervalle." /></Label>
+          <div className="grid grid-cols-2 gap-3">
+            <Input type="number" value={filters.positionRange[0]} onChange={(e) => setFilters({ ...filters, positionRange: [Number(e.target.value || 0), filters.positionRange[1]] })} />
+            <Input type="number" value={filters.positionRange[1]} onChange={(e) => setFilters({ ...filters, positionRange: [filters.positionRange[0], Number(e.target.value || 0)] })} />
+          </div>
         </div>
         <div className="space-y-1">
           <Label className="flex items-center gap-2">Filtre URL <HelpTooltip content="Afficher uniquement les lignes dont l'URL contient ou correspond à ce texte." /></Label>

--- a/src/features/estimator/types.ts
+++ b/src/features/estimator/types.ts
@@ -65,6 +65,8 @@ export interface FiltersState {
     minVolume: number;
     countryIn: string[];
     deviceIn: string[];
+    intentIn: string[];
+    positionRange: [number, number];
     urlMode: "contains" | "exact";
     urlValue: string;
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -34,6 +34,8 @@ const DEFAULT_FILTERS = {
   minVolume: 50,
   countryIn: [] as string[],
   deviceIn: [] as string[],
+  intentIn: [] as string[],
+  positionRange: [1,100] as [number, number],
   urlMode: "contains" as "contains" | "exact",
   urlValue: "",
 };
@@ -64,6 +66,7 @@ export default function Index() {
   const urlOptions = useMemo(() => Array.from(new Set(mapped.map((r) => r.url).filter(Boolean))) as string[], [mapped]);
   const countryOptions = useMemo(() => Array.from(new Set(mapped.map((r) => r.country).filter(Boolean))) as string[], [mapped]);
   const deviceOptions = useMemo(() => Array.from(new Set(mapped.map((r) => r.device).filter(Boolean))) as string[], [mapped]);
+  const intentOptions = useMemo(() => Array.from(new Set(mapped.map((r) => r.intent).filter(Boolean))) as string[], [mapped]);
 
   const cleaned: KeywordRow[] = useMemo(() => {
     return mapped
@@ -71,6 +74,8 @@ export default function Index() {
       .filter((r) => filterBrand(r, filters))
       .filter((r) => filterCountry(r, filters))
       .filter((r) => filterDevice(r, filters))
+      .filter((r) => filterIntent(r, filters))
+      .filter((r) => filterPosition(r, filters))
       .filter((r) => filterUrl(r, filters));
   }, [mapped, filters]);
 
@@ -102,6 +107,7 @@ export default function Index() {
             urls={urlOptions}
             countries={countryOptions}
             devices={deviceOptions}
+            intents={intentOptions}
          />
 
         <div className="space-y-6">
@@ -142,6 +148,17 @@ export default function Index() {
     if (!f.deviceIn.length) return true;
     const d = String(r.device ?? "");
     return f.deviceIn.includes(d);
+  }
+
+  function filterIntent(r: KeywordRow, f: typeof DEFAULT_FILTERS) {
+    if (!f.intentIn.length) return true;
+    const i = String(r.intent ?? "");
+    return f.intentIn.includes(i);
+  }
+
+  function filterPosition(r: KeywordRow, f: typeof DEFAULT_FILTERS) {
+    const [min, max] = f.positionRange;
+    return r.position >= min && r.position <= max;
   }
 
   function filterUrl(r: KeywordRow, f: typeof DEFAULT_FILTERS) {


### PR DESCRIPTION
## Summary
- allow filtering simulation by keyword intent
- add position range filter to control included keywords

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any; see log)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a03f7aa4c8324b2fbdb6453a0fca8