### PR TITLE
feat: add Monte Carlo panel and responsive layout

### DIFF
--- a/src/features/estimator/components/MonteCarloPanel.tsx
+++ b/src/features/estimator/components/MonteCarloPanel.tsx
@@ -1,0 +1,27 @@
+import { Card } from "@/components/ui/card";
+import { ResponsiveContainer, LineChart, Line, XAxis, Tooltip, CartesianGrid } from "recharts";
+import { IterResult } from "../simulation";
+
+interface Props { stats: { median: number; p25: number; p75: number }; series: IterResult[]; }
+
+export default function MonteCarloPanel({ stats, series }: Props) {
+  const data = series.map((s, i) => ({ i: i + 1, inc: s.incrementalClicks }));
+  return (
+    <Card className="p-4 space-y-3">
+      <h3 className="text-sm font-medium">Simulation Monte Carlo</h3>
+      <div className="text-xs text-muted-foreground">
+        Médiane {fmt(stats.median)} • P25 {fmt(stats.p25)} • P75 {fmt(stats.p75)}
+      </div>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="i" tick={{ fontSize: 10 }} />
+          <Tooltip formatter={(v) => fmt(Number(v))} labelFormatter={(l) => `Itération ${l}`} />
+          <Line type="monotone" dataKey="inc" stroke="#8884d8" dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </Card>
+  );
+}
+
+function fmt(n: number) { return Math.round(n).toLocaleString(); }

--- a/src/features/estimator/simulation.ts
+++ b/src/features/estimator/simulation.ts
@@ -87,4 +87,11 @@ function assignRule(row: KeywordRow, settings: SettingsState) {
 }
 
 function shuffle<T>(arr: T[]) { for (let i = arr.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [arr[i], arr[j]] = [arr[j], arr[i]]; } }
-function quantile(arr: number[], q: number) { const idx = Math.floor((arr.length - 1) * q); return arr[idx] ?? 0; }
+function quantile(arr: number[], q: number) {
+  if (!arr.length) return 0;
+  const pos = (arr.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  const next = arr[base + 1] ?? arr[base];
+  return arr[base] + rest * (next - arr[base]);
+}


### PR DESCRIPTION
## Summary
- add Monte Carlo simulation panel with chart and stats
- improve main layout with scrollable sidebar and table
- refine Monte Carlo quantile calculation

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689b30ed8ab48324ac7a88ad0f15d1a3