### PR TITLE
feat: clarify buckets and MC summary

### DIFF
--- a/src/features/estimator/components/DataTable.tsx
+++ b/src/features/estimator/components/DataTable.tsx
@@ -1,7 +1,8 @@
 import { FixedSizeList as List, ListChildComponentProps } from "react-window";
 import { Card } from "@/components/ui/card";
 import { HelpTooltip } from "@/components/HelpTooltip";
-import { TableRow as RowType } from "../../estimator/types";
+import { Bucket, TableRow as RowType } from "../../estimator/types";
+import { BUCKET_LABELS } from "../../estimator/constants";
 
 interface Props { rows: RowType[]; height?: number; }
 
@@ -73,6 +74,9 @@ export default function DataTable({ rows, height = 520 }: Props) {
 
 function formatCell(r: RowType, key: any) {
   const v = (r as any)[key];
+  if (key === "baselineBucket" || key === "expectedBucket") {
+    return v ? BUCKET_LABELS[v as Bucket] : "";
+  }
   if (typeof v === "number") {
     if (key === "baselineCTR") return v.toFixed(2);
     if (key.toString().includes("Clicks")) return Math.round(v).toLocaleString();

--- a/src/features/estimator/components/MonteCarloPanel.tsx
+++ b/src/features/estimator/components/MonteCarloPanel.tsx
@@ -6,12 +6,13 @@ interface Props { stats: { median: number; p25: number; p75: number }; series: I
 
 export default function MonteCarloPanel({ stats, series }: Props) {
   const data = series.map((s, i) => ({ i: i + 1, inc: s.incrementalClicks }));
+  const avgShare = series.reduce((a, s) => a + s.improvingShare, 0) / series.length;
   return (
     <Card className="p-4 space-y-3">
       <h3 className="text-sm font-medium">Simulation Monte Carlo</h3>
-      <div className="text-xs text-muted-foreground">
-        Médiane {fmt(stats.median)} • P25 {fmt(stats.p25)} • P75 {fmt(stats.p75)}
-      </div>
+      <p className="text-xs text-muted-foreground">
+        {`Volume incrémental médian ${fmt(stats.median)} (P25 ${fmt(stats.p25)} • P75 ${fmt(stats.p75)}). En moyenne ${Math.round(avgShare * 100)}% des mots-clés s'améliorent.`}
+      </p>
       <ResponsiveContainer width="100%" height={200}>
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/features/estimator/components/Sidebar.tsx
+++ b/src/features/estimator/components/Sidebar.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { HelpTooltip } from "@/components/HelpTooltip";
-import { DEFAULT_COHORTS } from "../../estimator/constants";
+import { BUCKET_LABELS, DEFAULT_COHORTS } from "../../estimator/constants";
 import { ColumnMapping, CohortRule, CTRBuckets, EngineMode, ScoreWeights, SettingsState, FiltersState } from "../../estimator/types";
 
 interface ColumnMapperProps {
@@ -182,7 +182,7 @@ export default function Sidebar({ settings, setSettings, onReset, ctrError, head
         <div className="grid grid-cols-5 gap-2 text-xs">
           {(["B13","B46","B710","B1120","B21P"] as (keyof CTRBuckets)[]).map((k) => (
             <div key={k} className="space-y-1">
-              <Label>{k}</Label>
+              <Label>{BUCKET_LABELS[k]}</Label>
               <Input type="number" value={(settings.ctr as any)[k]} onChange={(e) => setCTR(k, Number(e.target.value || 0))} />
             </div>
           ))}
@@ -194,7 +194,7 @@ export default function Sidebar({ settings, setSettings, onReset, ctrError, head
         <TabsList className="grid grid-cols-2"><TabsTrigger value="heuristic">Heuristique</TabsTrigger><TabsTrigger value="score">Score</TabsTrigger></TabsList>
         <TabsContent value="heuristic">
           <Card className="p-4 space-y-3">
-            <h3 className="text-sm font-medium flex items-center gap-2">Cohortes <HelpTooltip content="Les cohortes heuristiques attribuent des probabilités d'amélioration selon des règles simples. La probabilité restante va vers B1120; si la somme dépasse 1, une erreur apparaît." /></h3>
+            <h3 className="text-sm font-medium flex items-center gap-2">Cohortes <HelpTooltip content={`Les cohortes heuristiques attribuent des probabilités d'amélioration selon des règles simples. La probabilité restante va vers ${BUCKET_LABELS.B1120}; si la somme dépasse 1, une erreur apparaît.`} /></h3>
             {settings.cohorts.map((c, i) => {
               const sum = c.probs.B13 + c.probs.B46 + c.probs.B710 + c.probs.stay;
               const leftover = Math.max(0, 1 - sum);
@@ -205,12 +205,12 @@ export default function Sidebar({ settings, setSettings, onReset, ctrError, head
                   <div className="grid grid-cols-4 gap-2 items-end text-xs">
                     {(["B13","B46","B710","stay"] as const).map((k) => (
                       <div key={k} className="space-y-1">
-                        <Label>{k}</Label>
+                        <Label>{k === "stay" ? "Rester" : BUCKET_LABELS[k]}</Label>
                         <Input type="number" step="0.01" value={(c.probs as any)[k]} onChange={(e) => setCohort(i, { probs: { ...c.probs, [k]: Number(e.target.value || 0) } as any })} />
                       </div>
                     ))}
                   </div>
-                  <p className="text-[11px] mt-2">Somme={(sum).toFixed(2)} | Reste→B1120={(leftover).toFixed(2)}</p>
+                  <p className="text-[11px] mt-2">Somme={(sum).toFixed(2)} | Reste→{BUCKET_LABELS.B1120}={(leftover).toFixed(2)}</p>
                 </div>
               );
             })}

--- a/src/features/estimator/constants.ts
+++ b/src/features/estimator/constants.ts
@@ -1,4 +1,12 @@
-import { CTRBuckets, CohortRule, ScoreWeights } from "./types";
+import { Bucket, CTRBuckets, CohortRule, ScoreWeights } from "./types";
+
+export const BUCKET_LABELS: Record<Bucket, string> = {
+  B13: "1–3",
+  B46: "4–6",
+  B710: "7–10",
+  B1120: "11–20",
+  B21P: "21+",
+};
 
 export const DEFAULT_CTR: CTRBuckets = {
   B13: 22,

--- a/src/features/estimator/export.ts
+++ b/src/features/estimator/export.ts
@@ -1,6 +1,7 @@
 import * as XLSX from "xlsx";
 import Papa from "papaparse";
-import { TableRow } from "./types";
+import { Bucket, TableRow } from "./types";
+import { BUCKET_LABELS } from "./constants";
 
 export function exportTableCSV(rows: TableRow[], filename = "estimator-table.csv") {
   const csv = Papa.unparse(rows.map(r => ({
@@ -8,9 +9,9 @@ export function exportTableCSV(rows: TableRow[], filename = "estimator-table.csv
     Position: r.position,
     Volume: r.volume,
     Cohort: r.cohort,
-    BaselineBucket: r.baselineBucket,
+    BaselineBucket: BUCKET_LABELS[r.baselineBucket],
     BaselineCTR: r.baselineCTR,
-    ExpectedBucket: r.expectedBucket,
+    ExpectedBucket: r.expectedBucket ? BUCKET_LABELS[r.expectedBucket as Bucket] : "",
     ExpectedPosition: r.expectedPosition,
     BaselineSessions: r.baselineClicks,
     EstimatedSessions: r.estimatedClicks,
@@ -30,9 +31,9 @@ export function exportTableXLSX(rows: TableRow[], filename = "estimator-table.xl
     Position: r.position,
     Volume: r.volume,
     Cohort: r.cohort,
-    BaselineBucket: r.baselineBucket,
+    BaselineBucket: BUCKET_LABELS[r.baselineBucket],
     BaselineCTR: r.baselineCTR,
-    ExpectedBucket: r.expectedBucket,
+    ExpectedBucket: r.expectedBucket ? BUCKET_LABELS[r.expectedBucket as Bucket] : "",
     ExpectedPosition: r.expectedPosition,
     BaselineSessions: r.baselineClicks,
     EstimatedSessions: r.estimatedClicks,


### PR DESCRIPTION
## Summary
- add bucket label mapping for clearer UI and exports
- show incremental volume and improvement share in Monte Carlo summary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b3bcf21c8832486a156c5edf96867