### PR TITLE
Add performance summary for session estimation

### DIFF
--- a/src/features/estimator/components/PerformanceSummary.tsx
+++ b/src/features/estimator/components/PerformanceSummary.tsx
@@ -1,0 +1,25 @@
+import { Card } from "@/components/ui/card";
+
+interface PerformanceSummaryProps {
+  baseline: number;
+  estimated: number;
+  incremental: number;
+  engine: "heuristic" | "score";
+}
+
+export default function PerformanceSummary({ baseline, estimated, incremental, engine }: PerformanceSummaryProps) {
+  const percent = baseline > 0 ? (incremental / baseline) * 100 : 0;
+  const modelLabel = engine === "heuristic" ? "modèle heuristique" : "modèle par score";
+  return (
+    <Card className="p-4 text-sm leading-relaxed">
+      <p>
+        Avec le {modelLabel}, nous prévoyons <strong>{fmt(estimated)}</strong> sessions au total. Cela correspond à environ <strong>{fmt(incremental)}</strong> sessions supplémentaires par rapport à la situation actuelle, soit une amélioration d'environ {percent.toFixed(1)}%.
+      </p>
+    </Card>
+  );
+}
+
+function fmt(n: number) {
+  return Math.round(n).toLocaleString();
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import Sidebar from "@/features/estimator/components/Sidebar";
 import KPIs from "@/features/estimator/components/KPIs";
 import DataTable from "@/features/estimator/components/DataTable";
 import MonteCarloPanel from "@/features/estimator/components/MonteCarloPanel";
+import PerformanceSummary from "@/features/estimator/components/PerformanceSummary";
 import { parseFile, mapAndClean } from "@/features/estimator/parser";
 import { computeTable } from "@/features/estimator/model";
 import { monteCarlo } from "@/features/estimator/simulation";
@@ -132,6 +133,13 @@ export default function Index() {
             improvingShare={totals.improvingShare}
             mcActive={settings.monteCarlo}
             mcStats={mc?.stats}
+          />
+
+          <PerformanceSummary
+            baseline={totals.baselineClicks}
+            estimated={totals.estimatedClicks}
+            incremental={totals.incrementalClicks}
+            engine={settings.engine}
           />
 
           {settings.monteCarlo && mc ? <MonteCarloPanel stats={mc.stats} series={mc.series} /> : null}


### PR DESCRIPTION
## Summary
- add `PerformanceSummary` component to explain expected sessions and gains for heuristic or score models
- integrate performance summary into main page for clear novice-friendly guidance

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689b3e26cf4c8324bfba78beaf9a44f0