### PR TITLE
Enhance Monte Carlo result explanation

### DIFF
--- a/src/features/estimator/components/KPIs.tsx
+++ b/src/features/estimator/components/KPIs.tsx
@@ -15,7 +15,12 @@ export default function KPIs({ baseline, estimated, incremental, keywords, impro
   return (
     <section className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4">
       <KPICard title="Sessions de base" help="Sessions aux positions actuelles : Volume × CTR du groupe actuel." value={fmt(baseline)} />
-      <KPICard title={mcActive ? "Sessions estimées (médiane MC)" : "Sessions estimées"} help={mcActive ? "Médiane Monte Carlo des sessions estimées." : "Attendu déterministe du modèle."} value={fmt(mcActive ? (mcStats?.median ?? estimated) : estimated)} sub={mcActive ? `P25 ${fmt(mcStats?.p25 ?? 0)} • P75 ${fmt(mcStats?.p75 ?? 0)}` : undefined} />
+      <KPICard
+        title={mcActive ? "Sessions estimées (médiane MC)" : "Sessions estimées"}
+        help={mcActive ? "Médiane Monte Carlo des sessions estimées." : "Attendu déterministe du modèle."}
+        value={fmt(mcActive ? (baseline + (mcStats?.median ?? 0)) : estimated)}
+        sub={mcActive ? `P25 ${fmt(baseline + (mcStats?.p25 ?? 0))} • P75 ${fmt(baseline + (mcStats?.p75 ?? 0))}` : undefined}
+      />
       <KPICard title="Incrémental" help="Estimé − Base (≥ 0); le gain des améliorations." value={fmt(incremental)} />
       <KPICard title="#Mots-clés" help="Nombre de lignes considérées après filtres (volume min., marque, etc.)." value={keywords.toLocaleString()} />
       <KPICard title="% en amélioration" help="Part des mots-clés attendus en progression (après capacité et effort)." value={(improvingShare * 100).toFixed(1) + "%"} />

--- a/src/features/estimator/components/PerformanceSummary.tsx
+++ b/src/features/estimator/components/PerformanceSummary.tsx
@@ -1,20 +1,48 @@
 import { Card } from "@/components/ui/card";
+import { MCStats } from "../types";
 
 interface PerformanceSummaryProps {
   baseline: number;
   estimated: number;
   incremental: number;
   engine: "heuristic" | "score";
+  mcActive: boolean;
+  mcStats?: MCStats | null;
+  capacity: number;
+  effort: "low" | "medium" | "high";
+  uplift: number;
 }
 
-export default function PerformanceSummary({ baseline, estimated, incremental, engine }: PerformanceSummaryProps) {
-  const percent = baseline > 0 ? (incremental / baseline) * 100 : 0;
+export default function PerformanceSummary({
+  baseline,
+  estimated,
+  incremental,
+  engine,
+  mcActive,
+  mcStats,
+  capacity,
+  effort,
+  uplift,
+}: PerformanceSummaryProps) {
   const modelLabel = engine === "heuristic" ? "modèle heuristique" : "modèle par score";
+  const effortLabel = effort === "low" ? "faible" : effort === "high" ? "élevé" : "moyen";
+  const total = mcActive && mcStats ? baseline + mcStats.median : estimated;
+  const incr = total - baseline;
+  const percent = baseline > 0 ? (incr / baseline) * 100 : 0;
+
   return (
-    <Card className="p-4 text-sm leading-relaxed">
+    <Card className="p-4 text-sm leading-relaxed space-y-1">
       <p>
-        Avec le {modelLabel}, nous prévoyons <strong>{fmt(estimated)}</strong> sessions au total. Cela correspond à environ <strong>{fmt(incremental)}</strong> sessions supplémentaires par rapport à la situation actuelle, soit une amélioration d'environ {percent.toFixed(1)}%.
+        {`Actuellement ${fmt(baseline)} sessions. Avec ${uplift}pp d'uplift, ${capacity}% de capacité et un effort ${effortLabel}, le ${modelLabel} prévoit ${fmt(total)} sessions.`}
       </p>
+      <p>
+        {`Cela représente ${fmt(incr)} sessions supplémentaires (~${percent.toFixed(1)}%). Les valeurs se mettent à jour quand vous modifiez les paramètres.`}
+      </p>
+      {mcActive && mcStats ? (
+        <p className="text-xs text-muted-foreground mt-1">
+          {`Simulation Monte Carlo : médiane ${fmt(baseline + mcStats.median)} • P25 ${fmt(baseline + mcStats.p25)} • P75 ${fmt(baseline + mcStats.p75)}`}
+        </p>
+      ) : null}
     </Card>
   );
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -140,6 +140,11 @@ export default function Index() {
             estimated={totals.estimatedClicks}
             incremental={totals.incrementalClicks}
             engine={settings.engine}
+            mcActive={settings.monteCarlo}
+            mcStats={mc?.stats}
+            capacity={settings.capacityCapPct}
+            effort={settings.effort}
+            uplift={settings.upliftPP}
           />
 
           {settings.monteCarlo && mc ? <MonteCarloPanel stats={mc.stats} series={mc.series} /> : null}


### PR DESCRIPTION
## Summary
- make the performance summary dynamic with Monte Carlo stats and current settings
- display Monte Carlo totals in the KPI cards
- wire up settings data to the summary component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4104ea9c83249109ddde8730fd52