### PR TITLE
Separate Monte Carlo result explanation

### DIFF
--- a/src/features/estimator/components/PerformanceSummary.tsx
+++ b/src/features/estimator/components/PerformanceSummary.tsx
@@ -1,13 +1,10 @@
 import { Card } from "@/components/ui/card";
-import { MCStats } from "../types";
 
 interface PerformanceSummaryProps {
   baseline: number;
   estimated: number;
   incremental: number;
   engine: "heuristic" | "score";
-  mcActive: boolean;
-  mcStats?: MCStats | null;
   capacity: number;
   effort: "low" | "medium" | "high";
   uplift: number;
@@ -18,31 +15,22 @@ export default function PerformanceSummary({
   estimated,
   incremental,
   engine,
-  mcActive,
-  mcStats,
   capacity,
   effort,
   uplift,
 }: PerformanceSummaryProps) {
   const modelLabel = engine === "heuristic" ? "modèle heuristique" : "modèle par score";
   const effortLabel = effort === "low" ? "faible" : effort === "high" ? "élevé" : "moyen";
-  const total = mcActive && mcStats ? baseline + mcStats.median : estimated;
-  const incr = total - baseline;
-  const percent = baseline > 0 ? (incr / baseline) * 100 : 0;
+  const percent = baseline > 0 ? (incremental / baseline) * 100 : 0;
 
   return (
     <Card className="p-4 text-sm leading-relaxed space-y-1">
       <p>
-        {`Actuellement ${fmt(baseline)} sessions. Avec ${uplift}pp d'uplift, ${capacity}% de capacité et un effort ${effortLabel}, le ${modelLabel} prévoit ${fmt(total)} sessions.`}
+        {`Actuellement ${fmt(baseline)} sessions. Avec ${uplift}pp d'uplift, ${capacity}% de capacité et un effort ${effortLabel}, le ${modelLabel} prévoit ${fmt(estimated)} sessions.`}
       </p>
       <p>
-        {`Cela représente ${fmt(incr)} sessions supplémentaires (~${percent.toFixed(1)}%). Les valeurs se mettent à jour quand vous modifiez les paramètres.`}
+        {`Cela représente ${fmt(incremental)} sessions supplémentaires (~${percent.toFixed(1)}%). Les valeurs se mettent à jour quand vous modifiez les paramètres.`}
       </p>
-      {mcActive && mcStats ? (
-        <p className="text-xs text-muted-foreground mt-1">
-          {`Simulation Monte Carlo : médiane ${fmt(baseline + mcStats.median)} • P25 ${fmt(baseline + mcStats.p25)} • P75 ${fmt(baseline + mcStats.p75)}`}
-        </p>
-      ) : null}
     </Card>
   );
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -140,8 +140,6 @@ export default function Index() {
             estimated={totals.estimatedClicks}
             incremental={totals.incrementalClicks}
             engine={settings.engine}
-            mcActive={settings.monteCarlo}
-            mcStats={mc?.stats}
             capacity={settings.capacityCapPct}
             effort={settings.effort}
             uplift={settings.upliftPP}


### PR DESCRIPTION
## Summary
- Remove Monte Carlo statistics from the performance summary so heuristics/score results stand alone
- Keep Monte Carlo details in its own panel to avoid mixed explanations

## Testing
- `npm run lint` *(fails: Unexpected any & require import issues)*

------
https://chatgpt.com/codex/tasks/task_e_689b536674e48324b23ff33df8ffc11a