### PR TITLE
Use Gemini to group topics and fix brand filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.11.3",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -769,6 +770,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.11.5.tgz",
+      "integrity": "sha512-DviMgrnljEKh6qkDT2pVFW+NEuVhggqBUoEnyy2PNL7l4ewxXRJubk3PctC9yPl1AdRIlhqP7E076QQt+IWuTg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.83.0",
+    "@google/generative-ai": "^0.11.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,0 +1,21 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+
+export async function categorizeKeywords(keywords: string[]): Promise<Record<string, string>> {
+  if (!apiKey || !keywords.length) return {};
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: "gemini-pro" });
+    const prompt = `Group the following keywords into high-level topics.\n` +
+      `Return JSON mapping each keyword to a topic.\n` +
+      keywords.map((k) => `- ${k}`).join("\n");
+    const result = await model.generateContent(prompt);
+    const text = result.response.text();
+    const json = JSON.parse(text.match(/\{[\s\S]*\}/)?.[0] || "{}");
+    return json as Record<string, string>;
+  } catch (err) {
+    console.error("Gemini topic generation failed", err);
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary
- Integrate Gemini API to cluster keywords into semantic topics
- Refine brand filter to reduce false positives
- Add Google Generative AI dependency

## Testing
- `npm run lint` (fails: Unexpected any…)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b824fc9d88324a4c882d0158a12c2