### PR TITLE
Fix brand filter and ensure topic grouping fallback

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -2,12 +2,23 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
 
+function fallbackCategorize(keywords: string[]): Record<string, string> {
+  const mapping: Record<string, string> = {};
+  keywords.forEach((k) => {
+    const topic = k.toLowerCase().split(/\s+/).slice(0, 2).join(" ").trim();
+    if (topic) mapping[k] = topic;
+  });
+  return mapping;
+}
+
 export async function categorizeKeywords(keywords: string[]): Promise<Record<string, string>> {
-  if (!apiKey || !keywords.length) return {};
+  if (!keywords.length) return {};
+  if (!apiKey) return fallbackCategorize(keywords);
   try {
     const genAI = new GoogleGenerativeAI(apiKey);
     const model = genAI.getGenerativeModel({ model: "gemini-pro" });
-    const prompt = `Group the following keywords into high-level topics.\n` +
+    const prompt =
+      `Group the following keywords into high-level topics.\n` +
       `Return JSON mapping each keyword to a topic.\n` +
       keywords.map((k) => `- ${k}`).join("\n");
     const result = await model.generateContent(prompt);
@@ -16,6 +27,6 @@ export async function categorizeKeywords(keywords: string[]): Promise<Record<str
     return json as Record<string, string>;
   } catch (err) {
     console.error("Gemini topic generation failed", err);
-    return {};
+    return fallbackCategorize(keywords);
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,7 +15,6 @@ import { exportTableCSV, exportTableXLSX } from "@/features/estimator/export";
 import { generateSampleRows } from "@/features/estimator/sample";
 import { BRAND_INDEX } from "@/lib/brandIndex";
 import { normalizeText } from "@/lib/utils";
-import { distance as levenshtein } from "fastest-levenshtein";
 
 const DEFAULT_SETTINGS: SettingsState = {
   ctr: DEFAULT_CTR,
@@ -192,9 +191,14 @@ export default function Index() {
     const terms = Array.from(new Set([...BRAND_INDEX, ...manual]))
       .map((t) => normalizeText(t.trim()))
       .filter(Boolean);
-    const hay = normalizeText(`${r.keyword} ${(r.url ?? "")}`);
-    const words = hay.split(/\W+/).filter(Boolean);
-    const has = terms.some((t) => words.some((w) => levenshtein(w, t) <= (t.length > 5 ? 2 : 1)));
+
+    const hay = normalizeText(`${r.keyword} ${(r.url ?? "")}`)
+      .split(/\W+/)
+      .filter(Boolean)
+      .join(" ");
+    const paddedHay = ` ${hay} `;
+
+    const has = terms.some((t) => paddedHay.includes(` ${t} `));
     return f.brandMode === "include" ? has : !has;
   }
 


### PR DESCRIPTION
## Summary
- Avoid over-filtering keywords by matching brand terms at word boundaries
- Provide a fallback keyword grouping when Gemini API is unavailable

## Testing
- `npm run lint` *(fails: Fast refresh warnings and multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b8afee7788324b96ec1a761146bf5