### PR TITLE
Use Gemini API key by default for keyword clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Gemini API Key
+
+Keyword grouping uses Google's Gemini model. A default API key is bundled for
+testing, but you can supply your own by setting `VITE_GEMINI_API_KEY` in your
+environment.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/0fbc7e06-bd1d-4fae-a5ab-aa150a31b100) and click on Share -> Publish.

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,6 +1,11 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
-const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+// Use the provided Gemini API key by default so keyword categorization
+// works out-of-the-box. It can still be overridden via VITE_GEMINI_API_KEY
+// at runtime.
+const apiKey =
+  import.meta.env.VITE_GEMINI_API_KEY ||
+  "AIzaSyCoPnypnXr5LbLi0G49wg-8eFAhiBU0fDQ";
 
 function fallbackCategorize(keywords: string[]): Record<string, string> {
   const mapping: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- default Gemini API key added to semantic keyword categorization
- document Gemini key usage

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c49607860832487a8c02adf1b7c91